### PR TITLE
Fix package json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,8 @@
   "type": "module",
   "scripts": {
     "build:vite": "remix vite:build",
-    "build:hono": "rollup -c"
+    "build:hono": "rollup -c",
+    "build": "npm run build:vite && npm run build:hono"
   },
   "dependencies": {
     "@hono/node-server": "^1.9.0",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "build:vite": "remix vite:build",
     "build:hono": "rollup -c",
-    "build": "npm run build:vite && npm run build:hono"
+    "build": "npm run build:vite && npm run build:hono",
+    "start": "node build/api.js"
   },
   "dependencies": {
     "@hono/node-server": "^1.9.0",

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "@remix-run/dev": "^2.8.1",
     "@types/node": "^20.11.17",
     "@types/react": "^18.2.73",
+    "@types/react-dom": "^18.2.23",
     "concurrently": "^8.2.2",
     "tsx": "^4.7.1",
     "vite": "^5.2.7",

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,6 @@
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",
     "concurrently": "^8.2.2",
-    "tsc": "^2.0.4",
     "vite": "^5.2.7",
     "vite-tsconfig-paths": "^4.3.2"
   }

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",
     "concurrently": "^8.2.2",
+    "tsc": "^2.0.4",
     "tsx": "^4.7.1",
     "vite": "^5.2.7",
     "vite-tsconfig-paths": "^4.3.2"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "concurrently \"vite build --watch\" \"tsx --watch api/index.ts\""
+    "build:vite": "remix vite:build",
+    "build:hono": "rollup -c"
   },
   "dependencies": {
     "@hono/node-server": "^1.9.0",
@@ -17,10 +18,13 @@
   "devDependencies": {
     "@biomejs/biome": "1.6.3",
     "@remix-run/dev": "^2.8.1",
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@types/node": "^20.11.17",
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",
     "concurrently": "^8.2.2",
+    "rollup": "^4.13.2",
     "typescript": "^5.4.3",
     "vite": "^5.2.7",
     "vite-tsconfig-paths": "^4.3.2"

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,6 @@
     "@types/react-dom": "^18.2.23",
     "concurrently": "^8.2.2",
     "tsc": "^2.0.4",
-    "tsx": "^4.7.1",
     "vite": "^5.2.7",
     "vite-tsconfig-paths": "^4.3.2"
   }

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",
     "concurrently": "^8.2.2",
+    "typescript": "^5.4.3",
     "vite": "^5.2.7",
     "vite-tsconfig-paths": "^4.3.2"
   }

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -10,13 +10,13 @@ dependencies:
     version: 1.9.1
   '@remix-run/node':
     specifier: ^2.8.1
-    version: 2.8.1
+    version: 2.8.1(typescript@5.4.3)
   '@remix-run/react':
     specifier: ^2.8.1
-    version: 2.8.1(react-dom@18.2.0)(react@18.2.0)
+    version: 2.8.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.3)
   '@remix-run/serve':
     specifier: ^2.8.1
-    version: 2.8.1
+    version: 2.8.1(typescript@5.4.3)
   hono:
     specifier: ^4.1.5
     version: 4.1.5
@@ -31,7 +31,7 @@ dependencies:
     version: 18.2.0(react@18.2.0)
   remix-hono:
     specifier: ^0.0.16
-    version: 0.0.16
+    version: 0.0.16(typescript@5.4.3)
 
 devDependencies:
   '@biomejs/biome':
@@ -39,25 +39,37 @@ devDependencies:
     version: 1.6.3
   '@remix-run/dev':
     specifier: ^2.8.1
-    version: 2.8.1(@remix-run/serve@2.8.1)(@types/node@20.12.2)(vite@5.2.7)
+    version: 2.8.1(@remix-run/serve@2.8.1)(@types/node@20.12.2)(typescript@5.4.3)(vite@5.2.7)
+  '@rollup/plugin-commonjs':
+    specifier: ^25.0.7
+    version: 25.0.7(rollup@4.13.2)
+  '@rollup/plugin-typescript':
+    specifier: ^11.1.6
+    version: 11.1.6(rollup@4.13.2)(typescript@5.4.3)
   '@types/node':
     specifier: ^20.11.17
     version: 20.12.2
   '@types/react':
     specifier: ^18.2.73
     version: 18.2.73
+  '@types/react-dom':
+    specifier: ^18.2.23
+    version: 18.2.23
   concurrently:
     specifier: ^8.2.2
     version: 8.2.2
-  tsx:
-    specifier: ^4.7.1
-    version: 4.7.1
+  rollup:
+    specifier: ^4.13.2
+    version: 4.13.2
+  typescript:
+    specifier: ^5.4.3
+    version: 5.4.3
   vite:
     specifier: ^5.2.7
     version: 5.2.7(@types/node@20.12.2)
   vite-tsconfig-paths:
     specifier: ^4.3.2
-    version: 4.3.2(vite@5.2.7)
+    version: 4.3.2(typescript@5.4.3)(vite@5.2.7)
 
 packages:
 
@@ -1231,7 +1243,7 @@ packages:
     dev: true
     optional: true
 
-  /@remix-run/dev@2.8.1(@remix-run/serve@2.8.1)(@types/node@20.12.2)(vite@5.2.7):
+  /@remix-run/dev@2.8.1(@remix-run/serve@2.8.1)(@types/node@20.12.2)(typescript@5.4.3)(vite@5.2.7):
     resolution: {integrity: sha512-qFt4jAsAJeIOyg6ngeSnTG/9Z5N9QJfeThP/8wRHc1crqYgTiEtcI3DZ8WlAXjVSF5emgn/ZZKqzLAI02OgMfQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -1260,10 +1272,10 @@ packages:
       '@babel/types': 7.24.0
       '@mdx-js/mdx': 2.3.0
       '@npmcli/package-json': 4.0.1
-      '@remix-run/node': 2.8.1
+      '@remix-run/node': 2.8.1(typescript@5.4.3)
       '@remix-run/router': 1.15.3-pre.0
-      '@remix-run/serve': 2.8.1
-      '@remix-run/server-runtime': 2.8.1
+      '@remix-run/serve': 2.8.1(typescript@5.4.3)
+      '@remix-run/server-runtime': 2.8.1(typescript@5.4.3)
       '@types/mdx': 2.0.12
       '@vanilla-extract/integration': 6.5.0(@types/node@20.12.2)
       arg: 5.0.2
@@ -1303,6 +1315,7 @@ packages:
       set-cookie-parser: 2.6.0
       tar-fs: 2.1.1
       tsconfig-paths: 4.2.0
+      typescript: 5.4.3
       vite: 5.2.7(@types/node@20.12.2)
       ws: 7.5.9
     transitivePeerDependencies:
@@ -1320,7 +1333,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@remix-run/express@2.8.1(express@4.19.2):
+  /@remix-run/express@2.8.1(express@4.19.2)(typescript@5.4.3):
     resolution: {integrity: sha512-p1eo8uwZk8uLihSDpUnPOPsTDfghWikVPQfa+e0ZMk6tnJCjcpHAyENKDFtn9vDh9h7YNUg6A7+19CStHgxd7Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1330,10 +1343,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@remix-run/node': 2.8.1
+      '@remix-run/node': 2.8.1(typescript@5.4.3)
       express: 4.19.2
+      typescript: 5.4.3
 
-  /@remix-run/node@2.8.1:
+  /@remix-run/node@2.8.1(typescript@5.4.3):
     resolution: {integrity: sha512-ddCwBVlfLvRxTQJHPcaM1lhfMjsFYG3EGmYpWJIWnnzDX5EbX9pUNHBWisMuH1eA0c7pbw0PbW0UtCttKYx2qg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1342,7 +1356,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@remix-run/server-runtime': 2.8.1
+      '@remix-run/server-runtime': 2.8.1(typescript@5.4.3)
       '@remix-run/web-fetch': 4.4.2
       '@remix-run/web-file': 3.1.0
       '@remix-run/web-stream': 1.1.0
@@ -1350,8 +1364,9 @@ packages:
       cookie-signature: 1.2.1
       source-map-support: 0.5.21
       stream-slice: 0.1.2
+      typescript: 5.4.3
 
-  /@remix-run/react@2.8.1(react-dom@18.2.0)(react@18.2.0):
+  /@remix-run/react@2.8.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.3):
     resolution: {integrity: sha512-HTPm1U8+xz2jPaVjZnssrckfmFMA8sUZUdaWnoF5lmLWdReqcQv+XlBhIrQQ3jO9L8iYYdnzaSZZcRFYSdpTYg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1363,11 +1378,12 @@ packages:
         optional: true
     dependencies:
       '@remix-run/router': 1.15.3
-      '@remix-run/server-runtime': 2.8.1
+      '@remix-run/server-runtime': 2.8.1(typescript@5.4.3)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-router: 6.22.3(react@18.2.0)
       react-router-dom: 6.22.3(react-dom@18.2.0)(react@18.2.0)
+      typescript: 5.4.3
     dev: false
 
   /@remix-run/router@1.15.3:
@@ -1379,13 +1395,13 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /@remix-run/serve@2.8.1:
+  /@remix-run/serve@2.8.1(typescript@5.4.3):
     resolution: {integrity: sha512-PyCV7IMnRshwfFw7JJ2hZJppX88VAhZyYjeTAmYb6PK7IDtdmqUf5eOrYDi8gCu914C+aZRu6blxpLRlpyCY8Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@remix-run/express': 2.8.1(express@4.19.2)
-      '@remix-run/node': 2.8.1
+      '@remix-run/express': 2.8.1(express@4.19.2)(typescript@5.4.3)
+      '@remix-run/node': 2.8.1(typescript@5.4.3)
       chokidar: 3.6.0
       compression: 1.7.4
       express: 4.19.2
@@ -1396,7 +1412,7 @@ packages:
       - supports-color
       - typescript
 
-  /@remix-run/server-runtime@2.8.1:
+  /@remix-run/server-runtime@2.8.1(typescript@5.4.3):
     resolution: {integrity: sha512-fh4SOEoONrN73Kvzc0gMDCmYpVRVbvoj9j3BUXHAcn0An8iX+HD/22gU7nTkIBzExM/F9xgEcwTewOnWqLw0Bg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1411,6 +1427,7 @@ packages:
       cookie: 0.6.0
       set-cookie-parser: 2.6.0
       source-map: 0.7.4
+      typescript: 5.4.3
 
   /@remix-run/web-blob@3.1.0:
     resolution: {integrity: sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==}
@@ -1445,6 +1462,58 @@ packages:
     resolution: {integrity: sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==}
     dependencies:
       web-streams-polyfill: 3.3.3
+
+  /@rollup/plugin-commonjs@25.0.7(rollup@4.13.2):
+    resolution: {integrity: sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.2)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 8.1.0
+      is-reference: 1.2.1
+      magic-string: 0.30.8
+      rollup: 4.13.2
+    dev: true
+
+  /@rollup/plugin-typescript@11.1.6(rollup@4.13.2)(typescript@5.4.3):
+    resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.2)
+      resolve: 1.22.8
+      rollup: 4.13.2
+      typescript: 5.4.3
+    dev: true
+
+  /@rollup/pluginutils@5.1.0(rollup@4.13.2):
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 4.13.2
+    dev: true
 
   /@rollup/rollup-android-arm-eabi@4.13.2:
     resolution: {integrity: sha512-3XFIDKWMFZrMnao1mJhnOT1h2g0169Os848NhhmGweEcfJ4rCi+3yMCOLG4zA61rbJdkcrM/DjVZm9Hg5p5w7g==}
@@ -1619,6 +1688,12 @@ packages:
 
   /@types/prop-types@15.7.12:
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
+    dev: true
+
+  /@types/react-dom@18.2.23:
+    resolution: {integrity: sha512-ZQ71wgGOTmDYpnav2knkjr3qXdAFu0vsk8Ci5w3pGAIdj7/kKAyn+VsQDhXsmzzzepAiI9leWMmubXz690AI/A==}
+    dependencies:
+      '@types/react': 18.2.73
     dev: true
 
   /@types/react@18.2.73:
@@ -2043,6 +2118,10 @@ packages:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
     dev: true
 
+  /commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+    dev: true
+
   /compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -2434,6 +2513,10 @@ packages:
       '@types/unist': 2.0.10
     dev: true
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
@@ -2605,6 +2688,10 @@ packages:
       minipass: 7.0.4
     dev: true
 
+  /fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2650,12 +2737,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /get-tsconfig@4.7.3:
-    resolution: {integrity: sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==}
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-    dev: true
-
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2672,6 +2753,17 @@ packages:
       minimatch: 9.0.4
       minipass: 7.0.4
       path-scurry: 1.10.2
+    dev: true
+
+  /glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
     dev: true
 
   /globals@11.12.0:
@@ -2821,6 +2913,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -2926,6 +3025,12 @@ packages:
   /is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+    dev: true
+
+  /is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    dependencies:
+      '@types/estree': 1.0.5
     dev: true
 
   /is-reference@3.0.2:
@@ -3103,6 +3208,13 @@ packages:
   /lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+    dev: true
+
+  /magic-string@0.30.8:
+    resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /markdown-extensions@1.1.1:
@@ -3551,6 +3663,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimatch@9.0.4:
     resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3835,6 +3954,10 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+    dev: true
+
+  /path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
   /path-scurry@1.10.2:
@@ -4219,7 +4342,7 @@ packages:
       unified: 10.1.2
     dev: true
 
-  /remix-hono@0.0.16:
+  /remix-hono@0.0.16(typescript@5.4.3):
     resolution: {integrity: sha512-IPooI2E0eSFRV9wAgTzpsklSoOyij6Nsk6ANIugGhD9vYlovbYb2BT+siz++sLzWseZSPEtIzx/LBel203jBfQ==}
     peerDependencies:
       '@remix-run/cloudflare': ^2.0.0
@@ -4236,7 +4359,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@remix-run/server-runtime': 2.8.1
+      '@remix-run/server-runtime': 2.8.1(typescript@5.4.3)
       hono: 4.1.5
       pretty-cache-header: 1.0.0
     transitivePeerDependencies:
@@ -4252,13 +4375,18 @@ packages:
     resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
     dev: true
 
-  /resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-    dev: true
-
   /resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
+    dev: true
+
+  /resolve@1.22.8:
+    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.13.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
   /restore-cursor@3.1.0:
@@ -4581,6 +4709,11 @@ packages:
       has-flag: 4.0.0
     dev: true
 
+  /supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
     dependencies:
@@ -4657,7 +4790,7 @@ packages:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
     dev: true
 
-  /tsconfck@3.0.3:
+  /tsconfck@3.0.3(typescript@5.4.3):
     resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
     engines: {node: ^18 || >=20}
     hasBin: true
@@ -4666,6 +4799,8 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+    dependencies:
+      typescript: 5.4.3
     dev: true
 
   /tsconfig-paths@4.2.0:
@@ -4681,23 +4816,17 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
-  /tsx@4.7.1:
-    resolution: {integrity: sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    dependencies:
-      esbuild: 0.19.12
-      get-tsconfig: 4.7.3
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  /typescript@5.4.3:
+    resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   /ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
@@ -4886,7 +5015,7 @@ packages:
       - terser
     dev: true
 
-  /vite-tsconfig-paths@4.3.2(vite@5.2.7):
+  /vite-tsconfig-paths@4.3.2(typescript@5.4.3)(vite@5.2.7):
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
       vite: '*'
@@ -4896,7 +5025,7 @@ packages:
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 3.0.3
+      tsconfck: 3.0.3(typescript@5.4.3)
       vite: 5.2.7(@types/node@20.12.2)
     transitivePeerDependencies:
       - supports-color

--- a/app/rollup.config.mjs
+++ b/app/rollup.config.mjs
@@ -5,7 +5,8 @@ export default {
     input: "api/index.ts",
     output: {
         file: "build/api.js",
-        format: "esm"
+        format: "esm",
+        sourcemap: true
     },
     plugins: [
         typescript(),

--- a/app/rollup.config.mjs
+++ b/app/rollup.config.mjs
@@ -1,0 +1,14 @@
+import typescript from "@rollup/plugin-typescript";
+import commonjs from "@rollup/plugin-commonjs";
+
+export default {
+    input: "api/index.ts",
+    output: {
+        file: "build/api.js",
+        format: "esm"
+    },
+    plugins: [
+        typescript(),
+        commonjs(),
+    ]
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -6,10 +6,5 @@ import tsconfigPaths from "vite-tsconfig-paths";
 installGlobals();
 
 export default defineConfig({
-    server: {
-		watch: {
-			cwd: "app",
-		},
-	},
 	plugins: [remix(), tsconfigPaths()],
 });


### PR DESCRIPTION
## Overview

- Remove an unnecessary option of vite.config.ts
- Use rollup to build a Hono application
- Add start script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - Rollup設定を追加して、TypeScriptコードをESモジュール形式でバンドルできるようにしました。
- **変更点**
    - Vite設定から`server`設定ブロックと`watch`設定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->