### PR TITLE
Use arm64 runtime

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -172,6 +172,10 @@ resource "aws_ecs_task_definition" "mopetube_task_definition" {
       repositoryCredentials = {
         credentialsParameter = aws_secretsmanager_secret.mopetube_github_token.arn
       }
+      runtimePlatform = {
+        operatingSystemFamily = "LINUX"
+        cpuArchitecture       = "ARM64"
+      }
     }
   ])
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -159,6 +159,11 @@ resource "aws_ecs_task_definition" "mopetube_task_definition" {
 
   execution_role_arn = var.ecs_task_execution_role_arn
 
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
   container_definitions = jsonencode([
     {
       name  = "mopetube"
@@ -171,10 +176,6 @@ resource "aws_ecs_task_definition" "mopetube_task_definition" {
       ]
       repositoryCredentials = {
         credentialsParameter = aws_secretsmanager_secret.mopetube_github_token.arn
-      }
-      runtimePlatform = {
-        operatingSystemFamily = "LINUX"
-        cpuArchitecture       = "ARM64"
       }
     }
   ])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Updated the ECS task definition to support Linux operating system and ARM64 CPU architecture.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->